### PR TITLE
feat: Save config file override

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,13 @@ var rootCmd = &cobra.Command{
 		if cfgFile != "" {
 			viperReadType = "flag"
 			viper.SetConfigFile(cfgFile)
+
+			if configIsSaved {
+				lib.SaveConfig(cfgFile)
+				viper.SetConfigType("yaml")
+				viper.SetConfigName("config")
+				viper.AddConfigPath("$HOME/.config/anki-for-me")
+			}
 		} else {
 			viperReadType = "automatic"
 			viper.SetConfigType("yaml")
@@ -41,7 +48,7 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			switch viperReadType {
 			case "flag":
-				log.Fatal("Invalid file type, must be YAML format.")
+				log.Fatal("Invalid file, file must exist and be in YAML format.")
 			case "automatic":
 				if !strings.Contains(cmd.Name(), "init") {
 					log.Fatal("Please run anki-for-me init to initialize your config or pass in a config file using --config.")
@@ -52,8 +59,9 @@ var rootCmd = &cobra.Command{
 }
 
 var (
-	cfgFile string
-	sqlFile string
+	cfgFile       string
+	sqlFile       string
+	configIsSaved bool
 )
 
 func Execute() error {
@@ -61,5 +69,6 @@ func Execute() error {
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.config/anki-for-me/config.yaml")
+	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.config/anki-for-me/config.yaml")
+	rootCmd.PersistentFlags().BoolVarP(&configIsSaved, "save", "s", false, "Using this flag will override your config file with the one you entered using --config")
 }

--- a/lib/init.go
+++ b/lib/init.go
@@ -1,11 +1,11 @@
 package lib
 
 type Services struct {
-	Config *UserConfig
 	DB     Database
+	Config Config
 }
 
-func InitServices(config *UserConfig, db *Sqlite) *Services {
+func InitServices(config Config, db *Sqlite) *Services {
 	return &Services{
 		Config: config,
 		DB:     db,

--- a/lib/sql.go
+++ b/lib/sql.go
@@ -12,8 +12,8 @@ import (
 )
 
 type Database interface {
-	Exists(*Directory) bool
-	Create(*Directory) error
+	Exists(Directory) bool
+	Create(Directory) error
 	Connect(string) (*Sqlite, error)
 	Close()
 	// Delete() error
@@ -25,13 +25,13 @@ type Sqlite struct {
 	Connection *sql.DB
 }
 
-func (s *Sqlite) Exists(d *Directory) bool {
+func (s *Sqlite) Exists(d Directory) bool {
 	filename := filepath.Join(d.Path, "collections.db")
 	_, err := os.Stat(filename)
 	return err == nil
 }
 
-func (s *Sqlite) Create(d *Directory) error {
+func (s *Sqlite) Create(d Directory) error {
 	_, err := os.Create(path.Join(d.Path, "collections.db"))
 	return err
 }
@@ -55,7 +55,7 @@ func (s *Sqlite) Close() {
 	}
 }
 
-func NewSqlite(d *Directory) (*Sqlite, error) {
+func NewSqlite(d Directory) (*Sqlite, error) {
 	sqlite := &Sqlite{
 		nil,
 	}


### PR DESCRIPTION
Users can now save their config overrides permenantly by moving their config file into the config directory and renaming it config.yaml

It also creates a backup of their old file